### PR TITLE
feat: Added the new search endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,23 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
-replay_pid*
+
+# Build directory
+/target/
+
+# Eclipse files
+.classpath
+.project
+.settings
+bin/
+
+# IntelliJ files
+.idea/
+*.iml
+
+# Mac files
+.DS_Store
+._*
+
+# Vscode files
+.vscode/

--- a/docs/internal-endpoint-documentation.md
+++ b/docs/internal-endpoint-documentation.md
@@ -1,0 +1,62 @@
+# Internal User / Role Management APIs
+
+This page documents the API's available for the searching of users using a partial email and manage the roles assigned to them
+------------------------------------------------------------------------------------------------------------------------------
+
+<details>
+  <summary><code>GET</code> <code><b>/internal/users/search</b></code> <code>Gets the users that have the supplied 'sub string' in their email address</code></summary>
+
+### Parameters
+
+> | name              |  type     | data type      | description                                  |
+> |-------------------|-----------|----------------|----------------------------------------------|
+> | `partial_email`   |  required | string         | The partial email to search all users for    |
+
+### Responses
+
+> | http code     | content-type                      | response                                   |
+> |---------------|-----------------------------------|--------------------------------------------|
+> | `200`         | `application/json`                | `List of User Records`                     |
+> | `400`         | `application/json`                | `{"code":"400","message":"Bad Request"}`   |
+> | `404`         | `application/json`                | `{"code":"404","message":"Not Found"}`     |
+> | `500`         |  None                             | None                                       |
+
+### Example cURL
+
+#### Command 
+
+ ```javascript
+  curl -X GET -H "Content-Type: application/json" "http://api.chs.local:4001/internal/users/search?partial_email=demo"
+ ```
+#### Response
+```json
+[
+    {
+        "forename": null,
+        "surname": null,
+        "email": "demo@ch.gov.uk",
+        "user_id": "Y2VkZWVlMzhlZWFjY2M4MzQ3MT",
+        "display_name": null,
+        "roles": [
+            "supervisor",
+            "bados-user",
+            "bulk-refunds",
+            "chs-orders-investigator"
+        ],
+        "hasLinkedOneLogin": false,
+        "isPrivateBetaUser": false
+    },
+    {
+        "forename": null,
+        "surname": null,
+        "email": "demo2@ch.gov.uk",
+        "user_id": "Y2VkZWVlMzhlZWFjY2M4MzQ3MU",
+        "display_name": null,
+        "roles": [
+            "restricted-word"
+        ],
+        "hasLinkedOneLogin": false,
+        "isPrivateBetaUser": false
+    }
+]
+```

--- a/pom.xml
+++ b/pom.xml
@@ -14,8 +14,10 @@
     <properties>
         <java.version>21</java.version>
         <spring-boot.version>3.2.3</spring-boot.version>
+        <jib-maven-plugin.version>3.4.0</jib-maven-plugin.version>
         <maven.compiler.release>${java.version}</maven.compiler.release>
         <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
+        <jacoco-maven-plugin.version>0.8.10</jacoco-maven-plugin.version>
         <maven-surefire-plugin.version>3.2.2</maven-surefire-plugin.version>
         <structured-logging.version>3.0.3</structured-logging.version>
         <common-web-java.version>3.0.0</common-web-java.version>
@@ -23,7 +25,7 @@
         <sonar-maven-plugin.version>3.10.0.2594</sonar-maven-plugin.version>
         <encryption-java-library.version>2.0.3</encryption-java-library.version>
         <rest-service-common-library-version>2.0.2</rest-service-common-library-version>
-        <private-api-sdk-java.version>4.0.76</private-api-sdk-java.version>
+        <private-api-sdk-java.version>4.0.92</private-api-sdk-java.version>
         <api-sdk-manager-java-library.version>3.0.5</api-sdk-manager-java-library.version>
         <api-security-java-version>2.0.3</api-security-java-version>
         <org.mapstruct.version>1.5.5.Final</org.mapstruct.version>
@@ -159,7 +161,7 @@
             <plugin>
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>jib-maven-plugin</artifactId>
-                <version>3.4.0</version>
+                <version>${jib-maven-plugin.version}</version>
                 <configuration>
                     <from>
                         <image>416670754337.dkr.ecr.eu-west-2.amazonaws.com/ci-corretto-build-21</image>
@@ -184,6 +186,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco-maven-plugin.version}</version>
             </plugin>
             <plugin>
                 <groupId>org.sonarsource.scanner.maven</groupId>

--- a/src/main/java/uk/gov/companieshouse/accounts/user/controller/FindUserBasedOnPartialEmailController.java
+++ b/src/main/java/uk/gov/companieshouse/accounts/user/controller/FindUserBasedOnPartialEmailController.java
@@ -1,0 +1,64 @@
+package uk.gov.companieshouse.accounts.user.controller;
+
+import java.util.Objects;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
+import uk.gov.companieshouse.accounts.user.AccountsUserServiceApplication;
+import uk.gov.companieshouse.accounts.user.exceptions.BadRequestRuntimeException;
+import uk.gov.companieshouse.accounts.user.service.UsersService;
+import uk.gov.companieshouse.api.accounts.user.api.FindUsersBasedOnAPartialEmailInterface;
+import uk.gov.companieshouse.api.accounts.user.model.UsersList;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
+
+@RestController
+public class FindUserBasedOnPartialEmailController implements FindUsersBasedOnAPartialEmailInterface {
+
+    private final UsersService usersService;
+
+    private static final Logger LOG = LoggerFactory.getLogger(AccountsUserServiceApplication.applicationNameSpace);
+
+    public FindUserBasedOnPartialEmailController(UsersService usersService) {
+        this.usersService = usersService;
+    }
+
+    @Override
+    public ResponseEntity<UsersList> searchUsersDetailsUsingPartialEmail( final String xRequestId, final String partialEmail ) {
+
+        if(Objects.isNull(partialEmail) || partialEmail.isEmpty()){
+            LOG.error(String.format("%s: No partial email was provided.", xRequestId));
+            throw new BadRequestRuntimeException("Please check the request and try again");
+        }
+
+        LOG.debug( 
+            String.format( "%s: Attempting to search for users with an email address containing: %s",   xRequestId, partialEmail)
+        );
+
+        final UsersList users = new UsersList();            
+        StringBuilder userEmailList = new StringBuilder();
+
+        usersService.fetchUsersUsingPartialEmail(partialEmail).forEach(user  -> { 
+            users.add(user);
+            userEmailList.append(user.getEmail());
+        });
+
+        ResponseEntity<UsersList> response = new ResponseEntity<>( users, HttpStatus.NO_CONTENT);
+
+        if (! users.isEmpty() ) {
+            users.forEach(user -> userEmailList.append(user.getEmail()).append(" "));
+            LOG.debug( String.format( "%s: Successfully fetched %d users : %s",
+                    xRequestId, 
+                    users.size(), 
+                    userEmailList.toString()));
+            
+            response = new ResponseEntity<>( users, HttpStatus.OK );            
+        } else {
+            LOG.debug( String.format( "%s: Unable to find any of these users containing: %s",xRequestId, partialEmail) );
+        }
+
+        return response;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/accounts/user/repositories/UsersRepository.java
+++ b/src/main/java/uk/gov/companieshouse/accounts/user/repositories/UsersRepository.java
@@ -3,8 +3,7 @@ package uk.gov.companieshouse.accounts.user.repositories;
 import java.util.List;
 import java.util.Optional;
 
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Limit;
 import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.data.mongodb.repository.Query;
@@ -20,8 +19,7 @@ public interface UsersRepository extends MongoRepository<Users, String> {
 
     Optional<Users> findUsersById( String userId );
 
-    @Query("{email : { $regex : /?0/}}")
-    Page<Users> fetchUsersUsingPartialEmail(String subStringOfEmail, Pageable pageable);
+    List<Users> findUsersByEmailLike(String email, Limit limit);
 
     @Query( "{ 'id': ?0 }" )
     int updateUser( String userId, Update update );

--- a/src/main/java/uk/gov/companieshouse/accounts/user/repositories/UsersRepository.java
+++ b/src/main/java/uk/gov/companieshouse/accounts/user/repositories/UsersRepository.java
@@ -2,10 +2,14 @@ package uk.gov.companieshouse.accounts.user.repositories;
 
 import java.util.List;
 import java.util.Optional;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.data.mongodb.repository.Query;
 import org.springframework.stereotype.Repository;
+
 import uk.gov.companieshouse.accounts.user.models.Users;
 
 @Repository
@@ -15,6 +19,9 @@ public interface UsersRepository extends MongoRepository<Users, String> {
     List<Users> fetchUsers( List<String> emails );
 
     Optional<Users> findUsersById( String userId );
+
+    @Query("{email : { $regex : /?0/}}")
+    Page<Users> fetchUsersUsingPartialEmail(String subStringOfEmail, Pageable pageable);
 
     @Query( "{ 'id': ?0 }" )
     int updateUser( String userId, Update update );

--- a/src/main/java/uk/gov/companieshouse/accounts/user/service/UsersService.java
+++ b/src/main/java/uk/gov/companieshouse/accounts/user/service/UsersService.java
@@ -1,16 +1,23 @@
 package uk.gov.companieshouse.accounts.user.service;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
 import uk.gov.companieshouse.accounts.user.mapper.UsersDtoDaoMapper;
 import uk.gov.companieshouse.accounts.user.models.Users;
 import uk.gov.companieshouse.accounts.user.repositories.UsersRepository;
 import uk.gov.companieshouse.api.accounts.user.model.Role;
 import uk.gov.companieshouse.api.accounts.user.model.User;
-
-import java.util.*;
-import java.util.stream.Collectors;
 
 @Transactional
 @Service
@@ -18,6 +25,9 @@ public class UsersService {
 
     private final UsersRepository usersRepository;
     private final UsersDtoDaoMapper usersDtoDaoMapper;
+
+    @Value("${database.limit:50}")
+    private int limit;
 
     public UsersService(UsersRepository usersRepository, UsersDtoDaoMapper usersDtoDaoMapper) {
         this.usersRepository = usersRepository;
@@ -44,4 +54,15 @@ public class UsersService {
         return usersRepository.updateUser( userId, update );
     }
 
+    public List<User> fetchUsersUsingPartialEmail(final String partialEmail) {
+
+        List<Users> foundUsers = usersRepository
+                                        .fetchUsersUsingPartialEmail(partialEmail, PageRequest.of(0, limit))
+                                        .getContent();
+
+        return Objects.requireNonNullElse(foundUsers, new ArrayList<Users>())
+                .stream()
+                .map(usersDtoDaoMapper::daoToDto)
+                .collect(Collectors.toList());
+            }
 }

--- a/src/main/java/uk/gov/companieshouse/accounts/user/service/UsersService.java
+++ b/src/main/java/uk/gov/companieshouse/accounts/user/service/UsersService.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Limit;
 import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -56,10 +56,8 @@ public class UsersService {
 
     public List<User> fetchUsersUsingPartialEmail(final String partialEmail) {
 
-        List<Users> foundUsers = usersRepository
-                                        .fetchUsersUsingPartialEmail(partialEmail, PageRequest.of(0, limit))
-                                        .getContent();
-
+        List<Users> foundUsers = usersRepository.findUsersByEmailLike(partialEmail, Limit.of(limit));
+                    
         return Objects.requireNonNullElse(foundUsers, new ArrayList<Users>())
                 .stream()
                 .map(usersDtoDaoMapper::daoToDto)

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,3 +9,4 @@ management.endpoints.web.base-path= /users
 management.endpoints.web.path-mapping.health=healthcheck
 management.endpoint.health.enabled=true
 management.endpoint.health.show-details=never
+database.limit=50

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,4 +9,4 @@ management.endpoints.web.base-path= /users
 management.endpoints.web.path-mapping.health=healthcheck
 management.endpoint.health.enabled=true
 management.endpoint.health.show-details=never
-database.limit=50
+database.limit=${DATABASE_LIMIT:50}

--- a/src/test/java/uk/gov/companieshouse/accounts/user/controller/FindUserBasedOnPartialEmailControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/accounts/user/controller/FindUserBasedOnPartialEmailControllerTest.java
@@ -1,0 +1,142 @@
+package uk.gov.companieshouse.accounts.user.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import uk.gov.companieshouse.accounts.user.configuration.InterceptorConfig;
+import uk.gov.companieshouse.accounts.user.service.UsersService;
+import uk.gov.companieshouse.api.accounts.user.model.Role;
+import uk.gov.companieshouse.api.accounts.user.model.RolesList;
+import uk.gov.companieshouse.api.accounts.user.model.User;
+
+@Tag("unit-test")
+@WebMvcTest(FindUserBasedOnPartialEmailController.class)
+public class FindUserBasedOnPartialEmailControllerTest {
+
+    @Autowired
+    public MockMvc mockMvc;
+
+    @MockBean
+    UsersService usersService;
+
+    @MockBean
+    InterceptorConfig interceptorConfig;
+
+    private User eminem;
+    private User theRock;
+    private User harleyQuinn;
+    private User harryPotter;
+    @BeforeEach
+    void setup() {
+
+        final var supervisor = new RolesList();
+        supervisor.add(Role.SUPERVISOR);
+
+        eminem = new User();
+        eminem.userId("111")
+                .forename("Marshall")
+                .surname("Mathers")
+                .displayName("Eminem")
+                .email("eminem@rap.com")
+                .roles(supervisor);
+
+        final var badosUserAndRestrictedWord = new RolesList();
+        badosUserAndRestrictedWord.addAll(List.of(Role.BADOS_USER, Role.RESTRICTED_WORD));
+
+        theRock = new User();
+        theRock.userId("222")
+                .forename("Dwayne")
+                .surname("Johnson")
+                .displayName("The Rock")
+                .email("the.rock@wrestling.com")
+                .roles(badosUserAndRestrictedWord);
+
+        final var appealsTeam = new RolesList();
+        appealsTeam.add(Role.APPEALS_TEAM);
+
+        harleyQuinn = new User();
+        harleyQuinn.userId("333")
+                .forename("Harleen")
+                .surname("Quinzel")
+                .displayName("Harley Quinn")
+                .email("harley.quinn@gotham.city")
+                .roles(appealsTeam);
+
+        harryPotter = new User().userId("444")
+        .forename("Daniel")
+        .surname("Radcliff")
+        .displayName("Harry Potter")
+        .email("harry.potter@under-the-stairs.com");
+        
+
+        Mockito.doNothing().when(interceptorConfig).addInterceptors(any());
+    }
+
+    @Test
+    void searchUsersDetailsPartialEmailSingle() throws Exception {
+        
+        Mockito.doReturn(List.of(theRock)).when(usersService).fetchUsersUsingPartialEmail(any());
+
+        final var responseBody =
+                mockMvc.perform(get("/internal/users/search?partial_email=rock").header("X-Request-Id", "theId123"))
+                        .andExpect(status().isOk())
+                        .andReturn()
+                        .getResponse()
+                        .getContentAsString();
+
+        final var objectMapper = new ObjectMapper();
+        final var users = objectMapper.readValue(responseBody, new TypeReference<List<User>>(){});
+
+        Assertions.assertEquals(1, users.size());
+        Assertions.assertTrue(users.stream().map(User::getDisplayName).toList().containsAll(List.of("The Rock")));
+    }    
+    
+    @Test
+    void searchUsersDetailsPartialEmailMultiple() throws Exception {
+        
+        Mockito.doReturn(List.of(harleyQuinn,harryPotter)).when(usersService).fetchUsersUsingPartialEmail(any());
+
+        final var responseBody =
+                mockMvc.perform(get("/internal/users/search?partial_email=ha").header("X-Request-Id", "theId123"))
+                        .andExpect(status().isOk())
+                        .andReturn()
+                        .getResponse()
+                        .getContentAsString();
+
+        final var objectMapper = new ObjectMapper();
+        final var users = objectMapper.readValue(responseBody, new TypeReference<List<User>>(){});
+
+        Assertions.assertEquals(2, users.size());
+        
+        Assertions.assertTrue(users.stream().map(User::getDisplayName).allMatch(user -> (user.equals("Harry Potter")) || (user.equals("Harley Quinn"))));  
+  }
+
+   @Test
+   void searchUsersDetailsPartialBadRequestNull() throws Exception {
+        mockMvc.perform(get("/internal/users/search").header("X-Request-Id", "theId123"))
+                .andExpect(status().isBadRequest());
+        } 
+        
+        @Test
+        void searchUsersDetailsPartialBadRequestEmpty() throws Exception {
+             mockMvc.perform(get("/internal/users/search?partial_email").header("X-Request-Id", "theId123"))
+                     .andExpect(status().isBadRequest());
+             }         
+
+}

--- a/src/test/java/uk/gov/companieshouse/accounts/user/integration/FindUsersBasedOnPartialEmailControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/accounts/user/integration/FindUsersBasedOnPartialEmailControllerTest.java
@@ -1,0 +1,184 @@
+package uk.gov.companieshouse.accounts.user.integration;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import uk.gov.companieshouse.accounts.user.configuration.InterceptorConfig;
+import uk.gov.companieshouse.accounts.user.models.Users;
+import uk.gov.companieshouse.accounts.user.repositories.UsersRepository;
+import uk.gov.companieshouse.api.accounts.user.model.Role;
+import uk.gov.companieshouse.api.accounts.user.model.RolesList;
+import uk.gov.companieshouse.api.accounts.user.model.User;
+
+@AutoConfigureMockMvc
+@SpringBootTest
+@Testcontainers
+@Tag("integration-test")
+public class FindUsersBasedOnPartialEmailControllerTest {
+
+    @Container
+    @ServiceConnection
+    static MongoDBContainer container = new MongoDBContainer("mongo:5");
+
+    @Autowired
+    MongoTemplate mongoTemplate;
+
+    @Autowired
+    public MockMvc mockMvc;
+
+    @Autowired
+    UsersRepository usersRepository;
+
+    @MockBean
+    InterceptorConfig interceptorConfig;
+
+    @BeforeEach
+    public void setup() {
+
+        final var supervisor = new RolesList();
+        supervisor.add( Role.SUPERVISOR );
+
+        final var eminem = new Users();
+        eminem.setId( "111" );
+        eminem.setLocale( "GB_en" );
+        eminem.setForename( "Marshall" );
+        eminem.setSurname( "Mathers" );
+        eminem.setDisplayName( "Eminem" );
+        eminem.setEmail( "eminem@rap.com" );
+        eminem.setRoles( supervisor );
+        eminem.setCreated( LocalDateTime.now().minusDays( 1 ) );
+        eminem.setUpdated( LocalDateTime.now() );
+
+        final var badosUserAndRestrictedWord = new RolesList();
+        badosUserAndRestrictedWord.addAll( List.of( Role.BADOS_USER, Role.RESTRICTED_WORD ) );
+
+        final var theRock = new Users();
+        theRock.setId( "222" );
+        theRock.setLocale( "GB_en" );
+        theRock.setForename( "Dwayne" );
+        theRock.setSurname( "Johnson" );
+        theRock.setDisplayName( "The Rock" );
+        theRock.setEmail( "the.rock@wrestling.com" );
+        theRock.setRoles( badosUserAndRestrictedWord );
+        theRock.setCreated( LocalDateTime.now().minusDays( 4 ) );
+        theRock.setUpdated( LocalDateTime.now().minusDays( 2 ) );
+
+        final var appealsTeam = new RolesList();
+        appealsTeam.add( Role.APPEALS_TEAM );
+
+        final var harleyQuinn = new Users();
+        harleyQuinn.setId( "333" );
+        harleyQuinn.setLocale( "GB_en" );
+        harleyQuinn.setForename( "Harleen" );
+        harleyQuinn.setSurname( "Quinzel" );
+        harleyQuinn.setDisplayName( "Harley Quinn" );
+        harleyQuinn.setEmail( "harley.quinn@gotham.city" );
+        harleyQuinn.setRoles( appealsTeam );
+        harleyQuinn.setCreated( LocalDateTime.now().minusDays( 10 ) );
+        harleyQuinn.setUpdated( LocalDateTime.now().minusDays( 5 ) );
+
+
+        final var harryPotter = new Users();
+        harryPotter.setId( "444" );
+        harryPotter.setLocale( "GB_en" );
+        harryPotter.setForename( "Daniel" );
+        harryPotter.setSurname( "Radcliff" );
+        harryPotter.setDisplayName( "Harry Potter" );
+        harryPotter.setEmail( "harry.potter@under-the-stairs.com" );
+        harryPotter.setCreated( LocalDateTime.now().minusDays( 10 ) );
+        harryPotter.setUpdated( LocalDateTime.now().minusDays( 5 ) );
+
+        usersRepository.insert( List.of( eminem, theRock, harleyQuinn, harryPotter ) );
+
+        Mockito.doNothing().when(interceptorConfig).addInterceptors( any() );
+    }
+
+    @Test
+    void searchUsersWithoutQueryParamsReturnsBadRequest() throws Exception {
+        mockMvc.perform( get( "/internal/users/search" ).header("X-Request-Id", "theId123") ).andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void searchUsersWithMalformedEmailReturnsBadRequest() throws Exception {
+        mockMvc.perform( get( "/internal/users/search?partial_email" ).header("X-Request-Id", "theId123") ).andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void searchUsersWithNonExistentEmailsReturnsEmptyList() throws Exception {
+
+        final var responseBody =
+                mockMvc.perform( get( "/internal/users/search?partial_email=this.doesnt.exist@really.com" ).header("X-Request-Id", "theId123") )
+                        .andExpect(status().isNoContent())
+                        .andReturn()
+                        .getResponse()
+                        .getContentAsString();
+
+        final var objectMapper = new ObjectMapper();
+        final var users = objectMapper.readValue(responseBody, new TypeReference<List<User>>(){} );
+
+        Assertions.assertEquals( List.of(), users );
+    }
+
+    @Test
+    void searchUsersReturnsOneUser() throws Exception {
+
+        final var responseBody =
+        mockMvc.perform( get( "/internal/users/search?partial_email=harley.quinn@gotham.city" ).header("X-Request-Id", "theId123") )
+               .andExpect(status().isOk())
+               .andReturn()
+               .getResponse()
+               .getContentAsString();
+
+        final var objectMapper = new ObjectMapper();
+        final var users = objectMapper.readValue(responseBody, new TypeReference<List<User>>(){} );
+
+        Assertions.assertEquals( 1, users.size() );
+        Assertions.assertEquals( "Harley Quinn", users.get(0).getDisplayName() );
+    }
+
+    @Test
+    void searchUsersReturnsMultipleUsers() throws Exception {
+
+        final var responseBody = mockMvc.perform( get( "/internal/users/search?partial_email=ha" ).header("X-Request-Id", "theId123") )
+                        .andExpect(status().isOk())
+                        .andReturn()
+                        .getResponse()
+                        .getContentAsString();
+
+        final var objectMapper = new ObjectMapper();
+        final var users = objectMapper.readValue(responseBody, new TypeReference<List<User>>(){} );
+
+        Assertions.assertEquals( 2, users.size() );
+        Assertions.assertTrue( users.stream().map( User::getDisplayName ).toList().containsAll( List.of( "Harry Potter", "Harley Quinn" ) ) );
+    }
+
+    @AfterEach
+    public void after() {
+        mongoTemplate.dropCollection( Users.class );
+    }
+
+}

--- a/src/test/java/uk/gov/companieshouse/accounts/user/repositories/UsersRepositoryTest.java
+++ b/src/test/java/uk/gov/companieshouse/accounts/user/repositories/UsersRepositoryTest.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -12,12 +13,14 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.mongodb.UncategorizedMongoDbException;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Update;
 import org.testcontainers.containers.MongoDBContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+
 import uk.gov.companieshouse.accounts.user.models.OneLoginDataDao;
 import uk.gov.companieshouse.accounts.user.models.Users;
 import uk.gov.companieshouse.api.accounts.user.model.Role;
@@ -177,5 +180,18 @@ public class UsersRepositoryTest {
         Assertions.assertEquals( List.of( Role.SUPPORT_MEMBER ), usersRepository.findUsersById( "333" ).get().getRoles() );
     }
 
+    @Test
+    void fetchUsersUsingPartialEmail(){
+        final var oneUser = usersRepository.fetchUsersUsingPartialEmail("city", PageRequest.of(0, 50)).getContent();
+        final var multipleUsers = usersRepository.fetchUsersUsingPartialEmail("ha", PageRequest.of(0, 50)).getContent();
+
+        Assertions.assertEquals(1, oneUser.size());
+        Assertions.assertEquals("Harley Quinn", oneUser.get(0).getDisplayName());
+
+        Assertions.assertEquals(2, multipleUsers.size());
+        
+        Assertions.assertTrue(multipleUsers.stream()
+                                            .map(Users::getDisplayName).allMatch(user -> (user.equals("Harry Potter")) || (user.equals("Harley Quinn"))));
+    }
 
 }

--- a/src/test/java/uk/gov/companieshouse/accounts/user/repositories/UsersRepositoryTest.java
+++ b/src/test/java/uk/gov/companieshouse/accounts/user/repositories/UsersRepositoryTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
-import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Limit;
 import org.springframework.data.mongodb.UncategorizedMongoDbException;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Update;
@@ -182,8 +182,8 @@ public class UsersRepositoryTest {
 
     @Test
     void fetchUsersUsingPartialEmail(){
-        final var oneUser = usersRepository.fetchUsersUsingPartialEmail("city", PageRequest.of(0, 50)).getContent();
-        final var multipleUsers = usersRepository.fetchUsersUsingPartialEmail("ha", PageRequest.of(0, 50)).getContent();
+        final var oneUser = usersRepository.findUsersByEmailLike("city", Limit.of(50));
+        final var multipleUsers = usersRepository.findUsersByEmailLike("ha",  Limit.of(50)); Limit.of(50);
 
         Assertions.assertEquals(1, oneUser.size());
         Assertions.assertEquals("Harley Quinn", oneUser.get(0).getDisplayName());

--- a/src/test/java/uk/gov/companieshouse/accounts/user/service/UsersServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/accounts/user/service/UsersServiceTest.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+
 import org.bson.Document;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -21,8 +22,12 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.mongodb.UncategorizedMongoDbException;
 import org.springframework.data.mongodb.core.query.Update;
+import org.springframework.test.util.ReflectionTestUtils;
+
 import uk.gov.companieshouse.accounts.user.mapper.UsersDtoDaoMapper;
 import uk.gov.companieshouse.accounts.user.models.Users;
 import uk.gov.companieshouse.accounts.user.repositories.UsersRepository;
@@ -49,11 +54,11 @@ public class UsersServiceTest {
     private User userTheRock;
     private Users usersHarleyQuinn;
     private User userHarleyQuinn;
-    private Users harryPotter;
+    private Users usersHarryPotter;
+    private User userHarryPotter;
 
     @BeforeEach
     void setup(){
-
         usersEminem = new Users();
         usersEminem.setId( "111" );
         usersEminem.setLocale( "GB_en" );
@@ -120,15 +125,22 @@ public class UsersServiceTest {
                        .email("harley.quinn@gotham.city")
                        .roles( appealsTeam );
 
-        harryPotter = new Users();
-        harryPotter.setId( "444" );
-        harryPotter.setLocale( "GB_en" );
-        harryPotter.setForename( "Daniel" );
-        harryPotter.setSurname( "Radcliff" );
-        harryPotter.setDisplayName( "Harry Potter" );
-        harryPotter.setEmail( "harry.potter@under-the-stairs.com" );
-        harryPotter.setCreated( LocalDateTime.now().minusDays( 10 ) );
-        harryPotter.setUpdated( LocalDateTime.now().minusDays( 5 ) );
+        usersHarryPotter = new Users();
+        usersHarryPotter.setId("444");
+        usersHarryPotter.setLocale("GB_en");
+        usersHarryPotter.setForename("Daniel");
+        usersHarryPotter.setSurname("Radcliff");
+        usersHarryPotter.setDisplayName("Harry Potter");
+        usersHarryPotter.setEmail("harry.potter@under-the-stairs.com");
+        usersHarryPotter.setCreated(LocalDateTime.now().minusDays(10));
+        usersHarryPotter.setUpdated(LocalDateTime.now().minusDays(5));
+
+        userHarryPotter = new User();
+        userHarryPotter.userId("444");
+        userHarryPotter.setForename("Daniel");
+        userHarryPotter.setSurname("Radcliff");
+        userHarryPotter.setDisplayName("Harry Potter");
+        userHarryPotter.setEmail("harry.potter@under-the-stairs.com");
     }
 
     @Test
@@ -249,6 +261,20 @@ public class UsersServiceTest {
 
         usersService.setRoles( "444", List.of( Role.SUPPORT_MEMBER, Role.SUPPORT_MEMBER ) );
         Mockito.verify( usersRepository ).updateUser( eq("444"), argThat(setRolesUpdateParameterMatches( Set.of( Role.SUPPORT_MEMBER ) ) ) );
+    }
+
+    @Test
+    void fetchUsersUsingPartialEmail(){
+        ReflectionTestUtils.setField(usersService, "limit", 50);
+        Mockito.doReturn(new PageImpl<>(List.of(usersHarleyQuinn, usersHarryPotter))).when(usersRepository).fetchUsersUsingPartialEmail("har", PageRequest.of(0, 50));
+        Mockito.doReturn(userHarleyQuinn).when(usersDtoDaoMapper).daoToDto(usersHarleyQuinn);
+        Mockito.doReturn(userHarryPotter).when(usersDtoDaoMapper).daoToDto(usersHarryPotter);
+
+        final var multipleUsers = usersService.fetchUsersUsingPartialEmail("har");
+
+        Assertions.assertEquals(2, multipleUsers.size());
+        Assertions.assertTrue(multipleUsers.stream()
+                .map(User::getDisplayName).allMatch(user -> (user.equals("Harry Potter")) || (user.equals("Harley Quinn"))));
     }
 
 }

--- a/src/test/java/uk/gov/companieshouse/accounts/user/service/UsersServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/accounts/user/service/UsersServiceTest.java
@@ -22,8 +22,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Limit;
 import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.mongodb.UncategorizedMongoDbException;
 import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -266,7 +266,7 @@ public class UsersServiceTest {
     @Test
     void fetchUsersUsingPartialEmail(){
         ReflectionTestUtils.setField(usersService, "limit", 50);
-        Mockito.doReturn(new PageImpl<>(List.of(usersHarleyQuinn, usersHarryPotter))).when(usersRepository).fetchUsersUsingPartialEmail("har", PageRequest.of(0, 50));
+        Mockito.doReturn(List.of(usersHarleyQuinn, usersHarryPotter)).when(usersRepository).findUsersByEmailLike("har", Limit.of(50));
         Mockito.doReturn(userHarleyQuinn).when(usersDtoDaoMapper).daoToDto(usersHarleyQuinn);
         Mockito.doReturn(userHarryPotter).when(usersDtoDaoMapper).daoToDto(usersHarryPotter);
 

--- a/terraform/groups/ecs-service/locals.tf
+++ b/terraform/groups/ecs-service/locals.tf
@@ -7,7 +7,7 @@ locals {
   container_port             = "8080" # default Java port to match start script
   docker_repo                = "accounts-user-api"
   lb_listener_rule_priority  = 19
-  lb_listener_paths          = ["/users/*"]
+  lb_listener_paths          = ["/users/*", /internal/users/*"]
   healthcheck_path           = "/users/healthcheck" #healthcheck path for accounts association service
   healthcheck_matcher        = "200"
   application_subnet_ids     = data.aws_subnets.application.ids


### PR DESCRIPTION
  `/internal/users/search/` has been added for internal use
  allowing for partial serches on email addresses. The limit on the
  number of users returned is 50, but this can be configured.

CC-1248

__Short description outlining key changes/additions__

__JIRA Ticket Number__

### Type of change

* [ ] Bug fix
* [ ] New feature
* [ ] Breaking change
* [ ] Infrastructure change

### Pull request checklist

* [ ] I have added unit tests for new code that I have added
* [ ] I have added/updated functional tests where appropriate
* [ ] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/java.md)

__An exhaustive list of peer review checks can be read [here](https://github.com/companieshouse/styleguides/blob/master/java_review.md#developer-actions-prior-to-code-commitreview-started)__